### PR TITLE
conf: Dockerized API & MySQL container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 HELP.md
 .gradle
 build/
+data
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM gradle:6.9.0 as builder
+WORKDIR /usr/src/app
+COPY src ./src
+COPY build.gradle .
+RUN ["gradle"]
+
+EXPOSE 8080
+
+FROM adoptopenjdk/openjdk11:alpine-jre
+COPY build/libs/*.jar app.jar
+RUN apk --no-cache add curl
+ENTRYPOINT ["java", "-jar","app.jar"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,39 @@
+services:
+  st-helene-api:
+    build:
+      context: ./
+    hostname: api
+    #mem_limit: 350m
+    environment:
+      - SPRING_PROFILES_ACTIVE=docker
+    ports:
+      - "8080:8080"
+    depends_on:
+      st-helene-db:
+        condition: service_healthy
+  st-helene-db:
+    image: mysql:5.7
+    environment:
+      - MYSQL_ROOT_PASSWORD=rootpwd
+      - MYSQL_DATABASE=inventory_db
+      - MYSQL_USER=admin1
+      - MYSQL_PASSWORD=adminPass1
+    ports:
+      - "3306:3306"
+    volumes:
+      - ./data/st-helene-db:/var/lib/mysql
+      - ./src/main/resources/db:/docker-entrypoint-initdb.d
+    healthcheck:
+      test:
+        [
+            "CMD",
+            "mysqladmin",
+            "ping",
+            "-uuser",
+            "-ppwd",
+            "-h",
+            "localhost",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 10

--- a/src/main/java/com/depanneur_ste_helene/inventory_system/datalayer/Product.java
+++ b/src/main/java/com/depanneur_ste_helene/inventory_system/datalayer/Product.java
@@ -2,16 +2,31 @@ package com.depanneur_ste_helene.inventory_system.datalayer;
 import javax.persistence.*;
 
 @Entity
+@Table(name = "product")
 public class Product {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer productId;
+    
+    @Column(name = "bar_code", unique = true, nullable = false)
     private Integer barCode;
+    
+    @Column(name = "product_name")
     private String productName;
+    
+    @Column(name = "brand")
     private String brand;
+    
+    @Column(name = "price")
     private double price;
+    
+    @Column(name = "quantity")
     private Integer quantity;
+    
+    @Column(name = "quantity_sold")
     private Integer quantitySold;
+    
+    @Column(name = "category_id")
     private Integer categoryId;
 
     public Product(Integer productId, Integer barCode, String productName, String brand, double price, Integer quantity, Integer quantitySold, Integer categoryId) {

--- a/src/main/java/com/depanneur_ste_helene/inventory_system/presentationlayer/ProductRESTController.java
+++ b/src/main/java/com/depanneur_ste_helene/inventory_system/presentationlayer/ProductRESTController.java
@@ -28,7 +28,7 @@ public class ProductRESTController {
     @CrossOrigin
     @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE,
                 produces = MediaType.APPLICATION_JSON_VALUE,
-                path = "/product")
+                path = "/products")
     @ResponseStatus(HttpStatus.CREATED)
     public ProductDTO createProduct(@RequestBody ProductDTO product){
         return SERVICE.createProduct(product);
@@ -37,14 +37,14 @@ public class ProductRESTController {
     @CrossOrigin
     @PutMapping(consumes = MediaType.APPLICATION_JSON_VALUE,
                 produces = MediaType.APPLICATION_JSON_VALUE,
-                path = "/product/{barCode}")
+                path = "/products/{barCode}")
     public ProductDTO update(@RequestBody ProductDTO productDTO, @PathVariable("barCode") int barCode){
         productDTO.setBarCode(barCode);
         return SERVICE.updateProduct(productDTO);
     }
 
     @CrossOrigin
-    @DeleteMapping(path = "/product/{barCode}")
+    @DeleteMapping(path = "/products/{barCode}")
     public void deleteProduct(@PathVariable("barCode") int barCode){
         SERVICE.deleteProduct(barCode);
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
+spring.jpa.database-platform=org.hibernate.dialect.MySQL5Dialect
 spring.jpa.show-sql=false
 spring.jpa.hibernate.ddl-auto=none
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,7 @@
+spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
+spring.jpa.show-sql=false
 spring.jpa.hibernate.ddl-auto=none
+
 spring.datasource.url=jdbc:mysql://st-helene-db:3306/inventory_db
 spring.datasource.username=admin1
 spring.datasource.password=adminPass1

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
-spring.jpa.hibernate.ddl-auto=update
-spring.datasource.url=jdbc:mysql://${MYSQL_HOST:localhost}:3306/inventory_db
+spring.jpa.hibernate.ddl-auto=none
+spring.datasource.url=jdbc:mysql://st-helene-db:3306/inventory_db
 spring.datasource.username=admin1
 spring.datasource.password=adminPass1
 spring.datasource.driver-class-name= com.mysql.cj.jdbc.Driver

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,31 @@
+server:
+  error:
+    include-message: always
+
+logging:
+  level:
+    root: INFO
+    com.sthelene: DEBUG
+    org.hibernate.SQL: DEBUG
+    org.hibernate.type.descriptor.sql.BasicBinder: TRACE
+
+spring.profiles: docker
+
+spring:
+  datasource:
+    platform: mysql
+    url: jdbc:mysql://st-helene-db:3306/inventory_db
+    username: root
+    password: rootpwd
+    initialization-mode: always
+
+
+  # recommend setting this to "none" for production environments
+
+  jpa:
+    hibernate:
+      ddl-auto: none
+
+spring.datasource.hikari.initializationFailTimeout: 60000
+
+server.port: 8080

--- a/src/main/resources/db/01-product.sql
+++ b/src/main/resources/db/01-product.sql
@@ -1,0 +1,12 @@
+DROP TABLE IF EXISTS product;
+
+CREATE TABLE IF NOT EXISTS product (
+    productId INT(4) AUTO_INCREMENT PRIMARY KEY,
+    barCode INT(100),
+    brand VARCHAR(255),
+    categoryId INT(100),
+    price DOUBLE,
+    productName VARCHAR(255),
+    quantity INT(100),
+    quantitySold INT(100)
+) engine=InnoDB;

--- a/src/main/resources/db/01-product.sql
+++ b/src/main/resources/db/01-product.sql
@@ -1,12 +1,12 @@
 DROP TABLE IF EXISTS product;
 
 CREATE TABLE IF NOT EXISTS product (
-    productId INT(4) AUTO_INCREMENT PRIMARY KEY,
-    barCode INT(100),
+    product_id INT(4) AUTO_INCREMENT PRIMARY KEY,
+    bar_code INT(100),
     brand VARCHAR(255),
-    categoryId INT(100),
+    category_id INT(100),
     price DOUBLE,
-    productName VARCHAR(255),
+    product_name VARCHAR(255),
     quantity INT(100),
-    quantitySold INT(100)
+    quantity_sold INT(100)
 ) engine=InnoDB;

--- a/src/main/resources/db/01-product.sql
+++ b/src/main/resources/db/01-product.sql
@@ -2,7 +2,7 @@ DROP TABLE IF EXISTS product;
 
 CREATE TABLE IF NOT EXISTS product (
     product_id INT(4) AUTO_INCREMENT PRIMARY KEY,
-    bar_code INT(100),
+    bar_code INT(100) NOT NULL UNIQUE,
     brand VARCHAR(255),
     category_id INT(100),
     price DOUBLE,

--- a/src/main/resources/db/02-product.sql
+++ b/src/main/resources/db/02-product.sql
@@ -1,0 +1,2 @@
+INSERT IGNORE INTO product VALUES (1, 12345678, 'Pepsi', 1, 6.99, 'Pepsi', 10, 14);
+INSERT IGNORE INTO product VALUES (2, 2345678, 'Cola', 1, 4.20, 'Cola', 5, 9);


### PR DESCRIPTION
## Context
Made the API work run on a Docker container and be able to communicate with another container running MySQL.

## Changes
- Added docker-compose.yaml
- Added setup SQL scripts in the resource folder
- Changed application settings to be able to locate the Docker container

## Things to note
On first startup, the SQL scripts will be run from the resource folder and a data folder will be created in the root directory. If you want to start fresh with the mock data specified in the SQL scripts only again, delete the data folder and `docker-compose up` again. This _should_ get rid of data you've added and use only the records specified in the SQL script.
